### PR TITLE
Modify struct packet only in packet.h

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -55,10 +55,8 @@ int main(void) {
             return 1;
         }
 
-        ctx.request.head = request_buffer.bytes;
-        ctx.request.len = len;
-        ctx.response.head = response_buffer.bytes;
-        ctx.response.len = 0;
+        packet_init(&ctx.request, request_buffer.bytes, len);
+        packet_init(&ctx.response, response_buffer.bytes, sizeof(response_buffer));
 
         char ip[INET_ADDRSTRLEN];
         inet_ntop(AF_INET, &ctx.outer_remote_addr.sin_addr, ip, INET_ADDRSTRLEN);

--- a/src/packet.h
+++ b/src/packet.h
@@ -1,6 +1,7 @@
 #ifndef PACKET_H_
 #define PACKET_H_
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -16,18 +17,54 @@ struct packet {
     size_t len;
 };
 
-static inline void packet_shrink(struct packet *packet, size_t len) {
-    packet->head += len;
-    packet->len -= len;
+static inline void packet_init(struct packet *packet, void *head, size_t len) {
+    packet->head = head;
+    packet->len = len;
 }
 
-static inline void packet_expand(struct packet *packet, size_t len) {
-    packet->head -= len;
-    packet->len += len;
+static inline void *packet_pop_head(struct packet *packet, size_t len) {
+    if (packet->len < len) {
+        return NULL;
+    }
+
+    void *head = packet->head;
+    packet->head += len;
+    packet->len -= len;
+    return head;
+}
+
+static inline void *packet_peak_head(struct packet *packet, size_t len) {
+    if (packet->len < len) {
+        return NULL;
+    }
+
+    return packet->head;
 }
 
 static inline void packet_reserve(struct packet *packet, size_t len) {
-    packet->head += len;
+    void *head = packet_pop_head(packet, len);
+    assert(head);
+}
+
+static inline void *packet_push_head(struct packet *packet, size_t len) {
+    packet->head -= len;
+    packet->len += len;
+    return packet->head;
+}
+
+static inline void *packet_set_len(struct packet *packet, size_t len) {
+    assert(packet->len >= len);
+    packet->len = len;
+    return packet->head;
+}
+
+static inline void packet_pop_tail(struct packet *packet, size_t len) {
+    assert(packet->len >= len);
+    packet->len -= len;
+}
+
+static inline void packet_push_tail(struct packet *packet, size_t len) {
+    packet->len += len;
 }
 
 static inline void packet_pad(struct packet *packet, size_t n) {


### PR DESCRIPTION
Packet length was modified all over the place. Refactor and do modifications only in packet.h.