### PR TITLE
Enable More Compiler Warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,28 @@ project(
 add_project_arguments('-D_DEFAULT_SOURCE', language: 'c')
 
 cc = meson.get_compiler('c')
+
+add_project_arguments(
+    cc.get_supported_arguments(
+        [
+            '-Wundef',
+            '-Wmissing-include-dirs',
+            '-Wold-style-definition',
+            '-Wstrict-prototypes',
+            '-Wmissing-prototypes',
+            '-Walloca',
+            '-Wshadow',
+            '-Wcast-qual',
+            '-Wswitch-default',
+            '-Wswitch-enum',
+            '-Wredundant-decls',
+            '-Wundef',
+            '-Wnested-externs',
+        ],
+    ),
+    language: 'c',
+)
+
 fs = import('fs')
 
 # Strip relative path prefixes

--- a/src/inet/checksum.c
+++ b/src/inet/checksum.c
@@ -12,7 +12,7 @@ uint16_t inet_checksum(const void *data, size_t len) {
         len -= sizeof(*data16);
     }
     if (len) {
-        sum += *(uint8_t *)data16;
+        sum += *(const uint8_t *)data16;
     }
 
     // folding twice to cover the worst case

--- a/src/wireguard/hash.c
+++ b/src/wireguard/hash.c
@@ -6,16 +6,16 @@
 // Hash(input)
 //     Blake2s(input, 32), returning 32 bytes of output.
 
-void hash_init(hash_state *state) {
-    blake2s_init(state, BLAKE2S_OUTBYTES);
+void hash_init(struct hash_state *state) {
+    blake2s_init(&state->b2_state, BLAKE2S_OUTBYTES);
 }
 
-void hash_update(hash_state *state, const uint8_t *in, size_t inlen) {
-    blake2s_update(state, in, inlen);
+void hash_update(struct hash_state *state, const uint8_t *in, size_t inlen) {
+    blake2s_update(&state->b2_state, in, inlen);
 }
 
-void hash_final(hash_state *state, uint8_t *out) {
-    blake2s_final(state, out, BLAKE2S_OUTBYTES);
+void hash_final(struct hash_state *state, uint8_t *out) {
+    blake2s_final(&state->b2_state, out, BLAKE2S_OUTBYTES);
 }
 
 void hash_mix(uint8_t *hash, const uint8_t *in, size_t inlen) {
@@ -24,7 +24,7 @@ void hash_mix(uint8_t *hash, const uint8_t *in, size_t inlen) {
 
 void hash_mix_to(
         uint8_t *hash_out, const uint8_t *hash_in, const uint8_t *in, size_t inlen) {
-    hash_state state;
+    struct hash_state state;
     hash_init(&state);
     hash_update(&state, hash_in, BLAKE2S_OUTBYTES);
     hash_update(&state, in, inlen);

--- a/src/wireguard/hash.h
+++ b/src/wireguard/hash.h
@@ -9,11 +9,13 @@ enum {
     HASH_SIZE = BLAKE2S_OUTBYTES,
 };
 
-typedef blake2s_state hash_state;
+struct hash_state {
+    blake2s_state b2_state;
+};
 
-void hash_init(hash_state *state);
-void hash_update(hash_state *state, const uint8_t *in, size_t inlen);
-void hash_final(hash_state *state, uint8_t *out);
+void hash_init(struct hash_state *state);
+void hash_update(struct hash_state *state, const uint8_t *in, size_t inlen);
+void hash_final(struct hash_state *state, uint8_t *out);
 
 void hash_mix(uint8_t *hash, const uint8_t *in, size_t inlen);
 void hash_mix_to(

--- a/src/wireguard/wireguard.c
+++ b/src/wireguard/wireguard.c
@@ -75,7 +75,7 @@ static struct session
         g_sessions[1]; // NOLINT: will be replaced when multiple sessions are supported
 
 int wireguard_init(struct wireguard *wg, const uint8_t *private_key) {
-    hash_state hash_state;
+    struct hash_state hash_state;
 
     wg->private_key = private_key;
     dh_derive_public_key(wg->public_key, private_key);
@@ -126,7 +126,7 @@ int wireguard_handle_request(struct wireguard *wg, struct context *ctx) {
 }
 
 static int wireguard_handle_handshake(struct wireguard *wg, struct context *ctx) {
-    hash_state hash_state;
+    struct hash_state hash_state;
     struct kdf_state kdf_state;
     uint8_t hash[HASH_SIZE];
     uint8_t chaining_key[KDF_KEY_SIZE];


### PR DESCRIPTION
Enable and fix some new compiler warnings:
    ../src/inet/checksum.c:15:17: warning: cast discards ‘const’ qualifier from pointer target type [-Wcast-qual]
    ../src/wireguard/wireguard.c:78:16: warning: declaration of ‘hash_state’ shadows a global declaration [-Wshadow]