### PR TITLE
Write a Key Log File

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,9 @@ Checks:
   # Implementation of this check is too strict.
   # https://stackoverflow.com/a/58845898/5841556
   - '-hicpp-signed-bitwise'
+
+  # The fopen "e" mode is a glibc extension
+  - '-android-cloexec-fopen'
 CheckOptions:
   bugprone-misplaced-widening-cast.CheckImplicitCasts: '1'
   bugprone-suspicious-enum-usage.StrictMode: '1'

--- a/src/main.c
+++ b/src/main.c
@@ -15,12 +15,18 @@ int main(void) {
     }
     log_init(LOG_DEBUG);
 
+    FILE *key_log = fopen("salty-stun-keys", "w");
+    if (key_log == NULL) {
+        log_errnum_error("fopen salty-stun-keys");
+        return 1;
+    }
+
     struct wireguard wg;
     // yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk=
     static const uint8_t private_key[32] = { 0xc8, 0x09, 0xf3, 0xe5, 0x31, 0x7e, 0x95,
         0x75, 0xc9, 0xb5, 0xed, 0x78, 0xb6, 0x38, 0xb7, 0xce, 0x53, 0x0d, 0xab, 0xe8,
         0x5d, 0xda, 0xb6, 0x14, 0x22, 0x02, 0x41, 0x80, 0x1d, 0xdf, 0x06, 0x69 };
-    wireguard_init(&wg, private_key);
+    wireguard_init(&wg, private_key, key_log);
 
     // create UDP server
     int sockfd = socket(AF_INET, SOCK_DGRAM, 0);

--- a/src/wireguard/wireguard.h
+++ b/src/wireguard/wireguard.h
@@ -2,6 +2,7 @@
 #define WIREGUARD_H_
 
 #include <stdint.h>
+#include <stdio.h>
 
 #include "context.h"
 #include "wireguard/dh.h"
@@ -13,9 +14,10 @@ struct wireguard {
     uint8_t public_key[DH_PUBLIC_KEY_SIZE];
     uint8_t mac1_key[MAC_KEY_SIZE];
     uint8_t initial_hash[HASH_SIZE];
+    FILE *key_log;
 };
 
-int wireguard_init(struct wireguard *wg, const uint8_t *private_key);
+int wireguard_init(struct wireguard *wg, const uint8_t *private_key, FILE *key_log);
 int wireguard_handle_request(struct wireguard *wg, struct context *ctx);
 
 #endif // WIREGUARD_H_


### PR DESCRIPTION
The key log file can be used by Wireshark to decrypt captured packets.