### PR TITLE
wireguard: Fix Update Error in Sliding Window

### DIFF
--- a/src/wireguard/sliding_window.c
+++ b/src/wireguard/sliding_window.c
@@ -41,6 +41,7 @@ bool sliding_window_is_replay(struct sliding_window *swin, uint64_t counter,
 
     // mark as seen
     swin_new->bitmap = swin->bitmap | this_bit;
+    swin_new->last_counter = swin->last_counter;
 
     // out of order but good
     return false;

--- a/tests/test_wireguard.py
+++ b/tests/test_wireguard.py
@@ -182,3 +182,13 @@ def test_sliding_window_already_seen(salty_stun, salty_stun_socket):
         assert wg.request(ping, counter=0)
         wg.send(ping, counter=0)
         assert not salty_stun_socket.recv(4096)
+
+
+def test_sliding_window_update_error(salty_stun, salty_stun_socket):
+    ping = scapy.IP() / scapy.ICMP()
+
+    with testlib.WireGuardSession(salty_stun.public_key, salty_stun_socket) as wg:
+        assert wg.request(ping, counter=3)
+        assert wg.request(ping, counter=2)
+        wg.send(ping, counter=3)
+        assert not salty_stun_socket.recv(4096)


### PR DESCRIPTION
The last counter state was lost when an out of order packet was received.