### PR TITLE
args: Use string as log level argument

### DIFF
--- a/salty-stun.1.scd
+++ b/salty-stun.1.scd
@@ -35,13 +35,8 @@ NATs.
 	Wireshark. By default, keys are not logged.
 
 *-l* _level_
-	Set the log level to _level_. Valid values are integers between 0 and 3
-	(default 2).
-
-	- 0: error
-	- 1: warning
-	- 2: info
-	- 3: debug
+	Set the log level to _level_. Valid values are one of _error_, _warning_,
+	_info_ or _debug_. The default log level is _info_.
 
 *-n* _max_sessions_
 	Set the maximum number of concurrent sessions to _max_sessions_ (default

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -97,7 +97,7 @@ def test_args(args_runner):
         "-K",
         "-",
         "-l",
-        "3",
+        "debug",
         "-n",
         "42",
         "-f",

--- a/tests/testlib/_salty_stun.py
+++ b/tests/testlib/_salty_stun.py
@@ -15,7 +15,7 @@ class SaltyStun:
         max_sessions=None,
         address_family="IPv6",
     ):
-        self._args = [bin_path, "-l", "3", "-k", "-"]
+        self._args = [bin_path, "-l", "debug", "-k", "-"]
         self._port = port
         self._stdout = None
 


### PR DESCRIPTION
Using "-l debug" is easier to read than "-l3".