### PR TITLE
Add Plain STUN Mode

### DIFF
--- a/salty-stun.1.scd
+++ b/salty-stun.1.scd
@@ -24,7 +24,8 @@ NATs.
 	Show version information and exit.
 
 *-p* _port_
-	Listen on UDP port _port_ (default 51820).
+	Listen on UDP port _port_. The default port is 51820 or 3478 if running in
+	plain STUN mode (see *-P*).
 
 *-k* _key_file_
 	Read the private key from _key_file_. The key must be encoded in base64. By
@@ -45,6 +46,10 @@ NATs.
 *-f* _fd_
 	Accept incoming connections on file descriptor _fd_ instead of creating a
 	new socket.
+
+*-P*
+	Run in plain STUN mode: do not use WireGuard for transport. This is useful
+	when you want to use *salty-stun* as a regular STUN server.
 
 # EXAMPLE
 

--- a/src/args.c
+++ b/src/args.c
@@ -34,7 +34,8 @@ static const char HELP[] =
         "optional arguments:\n"
         "  -h               show this help message and exit\n"
         "  -V               output version information and exit\n"
-        "  -p PORT          listen on UDP port PORT (default %d)\n"
+        "  -p PORT          listen on UDP port PORT (default %d or %d in plain\n"
+        "                   mode)\n"
         "  -k KEY_FILE      read private key from KEY_FILE (default\n"
         "                   %s)\n"
         "  -K KEY_LOG       write keys to KEY_LOG, which can be used to decrypt the\n"
@@ -43,29 +44,32 @@ static const char HELP[] =
         "                   default is info)\n"
         "  -n MAX_SESSIONS  maximum number of WireGuard sessions (default %zu)\n"
         "  -f FD            listen on socket FD instead of creating a new socket\n"
+        "  -P               run in plain STUN mode, without WireGuard tunneling\n"
         "";
 static const char VERSION[] = "salty-stun " SALTY_STUN_VERSION "\n";
-static const char OPTSTRING[] = ":hVp:k:K:l:n:f:";
+static const char OPTSTRING[] = ":hVp:k:K:l:n:f:P";
 
 static const char DEFAULT_KEY_FILE[] = "/etc/salty-stun/private-key";
 static const uint16_t DEFAULT_PORT = 51820;
+static const uint16_t DEFAULT_PORT_PLAIN = 3478;
 static const size_t DEFAULT_MAX_SESSIONS = 1024;
 
 void parse_args(int argc, char *argv[], struct args *args) {
     bool has_key_file = false;
-    args->port = DEFAULT_PORT;
+    args->port = 0;
     args->key_log = NULL;
     args->level = LOG_INFO;
     args->max_sessions = DEFAULT_MAX_SESSIONS;
     args->sockfd = -1;
+    args->plain = false;
 
     int opt = 0;
     while ((opt = getopt(argc, argv, OPTSTRING)) != -1) {
         switch (opt) {
         case 'h':
             (void)fprintf(stdout, USAGE);
-            (void)fprintf(
-                    stdout, HELP, DEFAULT_PORT, DEFAULT_KEY_FILE, DEFAULT_MAX_SESSIONS);
+            (void)fprintf(stdout, HELP, DEFAULT_PORT, DEFAULT_PORT_PLAIN,
+                    DEFAULT_KEY_FILE, DEFAULT_MAX_SESSIONS);
             exit(0);
             break;
         case 'V':
@@ -103,6 +107,9 @@ void parse_args(int argc, char *argv[], struct args *args) {
                     optarg, min_fd, max_fd, "-f: invalid file descriptor");
             break;
         }
+        case 'P':
+            args->plain = true;
+            break;
         case ':':
             usage_error("option -%c requires an argument", optopt);
             break;
@@ -116,8 +123,12 @@ void parse_args(int argc, char *argv[], struct args *args) {
         usage_error("unrecognized argument: %s", argv[optind]);
     }
 
-    if (!has_key_file) {
+    if (!args->plain && !has_key_file) {
         read_key(DEFAULT_KEY_FILE, args->private_key);
+    }
+
+    if (args->port == 0) {
+        args->port = args->plain ? DEFAULT_PORT_PLAIN : DEFAULT_PORT;
     }
 }
 

--- a/src/args.h
+++ b/src/args.h
@@ -1,6 +1,7 @@
 #ifndef ARGS_H_
 #define ARGS_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "log.h"
@@ -13,6 +14,7 @@ struct args {
     enum log_level level;
     size_t max_sessions;
     int sockfd;
+    bool plain;
 };
 
 void parse_args(int argc, char *argv[], struct args *args);

--- a/tests/test_args.c
+++ b/tests/test_args.c
@@ -20,6 +20,8 @@ int main(int argc, char **argv) {
 
     printf("%d\n", args.sockfd);
 
+    printf("%d\n", args.plain);
+
     if (args.key_log) {
         (void)fprintf(args.key_log, "key log\n");
         (void)fflush(args.key_log);

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -25,7 +25,8 @@ class ArgsRunner:
             level=int(lines[2]),
             max_sessions=int(lines[3]),
             sockfd=int(lines[4]),
-            stdout=lines[5:],
+            plain=lines[5] == "1",
+            stdout=lines[6:],
         )
 
     def run(self, *args, input_=None):
@@ -58,6 +59,7 @@ class Args:
     max_sessions: int
     stdout: list[str]
     sockfd: int
+    plain: bool
 
 
 @pytest.fixture
@@ -73,6 +75,7 @@ def test_default_values(args_runner):
     assert args.max_sessions == 1024
     assert args.sockfd == -1
     assert args.stdout == []
+    assert args.plain == False
 
 
 def test_help(args_runner):
@@ -102,6 +105,7 @@ def test_args(args_runner):
         "42",
         "-f",
         "3",
+        "-P",
         input_=DUMMY_PUBLIC_KEY_B64,
     )
     assert args.port == 1234
@@ -110,6 +114,7 @@ def test_args(args_runner):
     assert args.max_sessions == 42
     assert args.sockfd == 3
     assert args.stdout == ["key log"]
+    assert args.plain == True
 
 
 def test_key_log_file(args_runner):

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -77,3 +77,46 @@ def test_production_ping(wg_session):
     expected_response = scapy.IP(id=0) / scapy.ICMP(type=0) / b"payload"
     expected_response = scapy.IP(scapy.raw(expected_response))
     assert response == expected_response
+
+
+@pytest.fixture(scope="module")
+def plain_stun_sock(pytestconfig):
+    port = 3478
+    builddir = pytestconfig.getoption("builddir")
+
+    with subprocess.Popen(
+        [builddir / "salty-stun", "-P"],
+        stderr=subprocess.PIPE,
+    ) as proc:
+        try:
+            for line in proc.stderr:
+                if b"Listening on port " in line:
+                    break
+
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect(("localhost", port))
+                yield sock
+        finally:
+            proc.terminate()
+
+
+def test_production_plain(plain_stun_sock):
+    request = scapy_stun.STUN(stun_message_type="Binding request")
+    request = scapy_stun.STUN(scapy.raw(request))
+    plain_stun_sock.send(bytes(request))
+    response = plain_stun_sock.recv(4096)
+    response = scapy_stun.STUN(response)
+
+    local_addr, local_port = plain_stun_sock.getsockname()[:2]
+    expected_attribute = scapy_stun.STUNXorMappedAddress(
+        xport=local_port, xip=local_addr
+    )
+
+    expected_response = scapy_stun.STUN(
+        stun_message_type="Binding success response",
+        transaction_id=request.transaction_id,
+        attributes=[expected_attribute],
+    )
+    expected_response = scapy_stun.STUN(scapy.raw(expected_response))
+
+    assert response == expected_response


### PR DESCRIPTION
In plain STUN mode salty-stun acts like a regular STUN server. This can be used to find the best path with regular ICE requests (since they can be parallelized) and then use a salty-stun server with WireGuard to get the public transport address for the fastest path.